### PR TITLE
The two methods for isActive in the helper Data.php are used excessively...

### DIFF
--- a/app/code/community/Sitewards/B2BProfessional/Helper/Data.php
+++ b/app/code/community/Sitewards/B2BProfessional/Helper/Data.php
@@ -179,4 +179,11 @@ class Sitewards_B2BProfessional_Helper_Data extends Mage_Core_Helper_Abstract {
 		}
 		return $bValidCart;
 	}
+
+	/**
+ 	 * @return string
+ 	 */
+ 	public function getOrderHistoryUrl() {
+ 		return $this->_getUrl('sales/order/history');
+ 	}
 }


### PR DESCRIPTION
... in the event core_block_abstract_to_html_before, so caching them improves performance a lot!
On my site, the homepage needed 2,6 seconds to load. After this fix, it was reduced to 1 second. It works, because Mage::helper() is a singleton and thus the variables can be cached over events, so all the computation is only done once instead of for each single event.
