### PR TITLE
Remove the setting if is salable attribute

### DIFF
--- a/app/code/community/Sitewards/B2BProfessional/Model/Observer.php
+++ b/app/code/community/Sitewards/B2BProfessional/Model/Observer.php
@@ -47,33 +47,6 @@ class Sitewards_B2BProfessional_Model_Observer
     }
 
     /**
-     * This will cover the case where the event 'catalog_product_is_salable_after' has not been called yet
-     *  - In the same data provided by magento the "swiss-movement-sports-watch" causes this issue
-     *
-     * @param Varien_Event_Observer $oObserver
-     */
-    public function catalogProductLoadAfter(Varien_Event_Observer $oObserver)
-    {
-        if ($this->isExtensionActive()) {
-            $this->setSalable($oObserver);
-        }
-    }
-
-    /**
-     * Check to see if a product can be sold to the current logged in user
-     *  - if the flag of salable is already false then we should do nothing
-     *
-     * @param Varien_Event_Observer $oObserver
-     */
-    public function catalogProductIsSalableAfter(Varien_Event_Observer $oObserver)
-    {
-        if ($this->isExtensionActive()) {
-            $this->setSalable($oObserver);
-            $this->setSalable($oObserver, 'salable');
-        }
-    }
-
-    /**
      * Check to see if the product being added to the cart can be bought
      *
      * @param Varien_Event_Observer $oObserver
@@ -298,20 +271,5 @@ class Sitewards_B2BProfessional_Model_Observer
     protected function getEventsProduct(Varien_Event_Observer $oObserver)
     {
         return $oObserver->getProduct();
-    }
-
-    /**
-     * Set the salable data on a given object
-     *
-     * @param Varien_Event_Observer $oObserver
-     * @param string $sObjectName
-     */
-    protected function setSalable(Varien_Event_Observer $oObserver, $sObjectName = 'product')
-    {
-        $oProduct = $this->getEventsProduct($oObserver);
-        $oObject  = $oObserver->getData($sObjectName);
-        if ($oObject !== null && $oObject->getIsSalable() == true) {
-            $oObject->setIsSalable($this->oB2BHelper->isProductActive($oProduct));
-        }
     }
 }

--- a/app/code/community/Sitewards/B2BProfessional/etc/config.xml
+++ b/app/code/community/Sitewards/B2BProfessional/etc/config.xml
@@ -19,24 +19,6 @@
     </global>
     <frontend>
         <events>
-            <catalog_product_load_after>
-                <observers>
-                    <sitewards_b2bprofessional>
-                        <type>singleton</type>
-                        <class>sitewards_b2bprofessional/observer</class>
-                        <method>catalogProductLoadAfter</method>
-                    </sitewards_b2bprofessional>
-                </observers>
-            </catalog_product_load_after>
-            <catalog_product_is_salable_after>
-                <observers>
-                    <sitewards_b2bprofessional>
-                        <type>singleton</type>
-                        <class>sitewards_b2bprofessional/observer</class>
-                        <method>catalogProductIsSalableAfter</method>
-                    </sitewards_b2bprofessional>
-                </observers>
-            </catalog_product_is_salable_after>
             <catalog_product_type_prepare_full_options>
                 <observers>
                     <sitewards_b2bprofessional>


### PR DESCRIPTION
We do this so that stock status is not modified. This means that the products real stock information will show rather than out of stock when the user cannot access the product. Sadly the add to cart button will also show but will not work if user has not access to product.
