### PR TITLE
RWD: View Details button instead of Add to cart on category page

### DIFF
--- a/app/code/community/Sitewards/B2BProfessional/Model/Observer.php
+++ b/app/code/community/Sitewards/B2BProfessional/Model/Observer.php
@@ -163,6 +163,7 @@ class Sitewards_B2BProfessional_Model_Observer
         foreach ($oProductCollection as $oProduct) {
             if ($this->oB2BHelper->isProductActive($oProduct) === false) {
                 $oProduct->setRequiredOptions(array($oDummyOption));
+                $oProduct->addOption($oDummyOption);
             }
         }
         return $oProductCollection;


### PR DESCRIPTION
RWD theme [will display "View Details" button][product_list], if [$product->canConfigure()][product_canConfigure] will return true.

[product_list]: https://github.com/speedupmate/Magento-CE-Mirror/blob/master/app/design/frontend/rwd/default/template/catalog/product/list.phtml#L89-L93
[product_canConfigure]: https://github.com/speedupmate/Magento-CE-Mirror/blob/master/app/code/core/Mage/Catalog/Model/Product.php#L1574