### PR TITLE
hide bundle prices from customers who are not logged in

### DIFF
--- a/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option.php
+++ b/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+
+/**
+ * Bundle option renderer
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+class Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option extends Mage_Bundle_Block_Catalog_Product_View_Type_Bundle_Option
+{
+
+    /**
+     * The b2b prof helper class
+     *
+     * @var Sitewards_B2BProfessional_Helper_Data
+     */
+    protected $oB2BHelper;
+
+    /**
+     * The b2b prof customer helper class
+     *
+     * @var Sitewards_B2BProfessional_Helper_Customer
+     */
+    protected $oB2BCustomerHelper;
+
+    public function __construct()
+    {
+        $this->oB2BHelper = Mage::helper('sitewards_b2bprofessional');
+        $this->oB2BCustomerHelper = Mage::helper('sitewards_b2bprofessional/customer');
+
+        parent::__construct();
+    }
+
+    /**
+     * Checks to see if the price can be shown.
+     *
+     * @return boolean
+     */
+    protected function _canShowPrice()
+    {
+        if(!$this->oB2BHelper->isExtensionActive())
+            return true;
+
+        return $this->oB2BCustomerHelper->isCustomerLoggedIn();
+    }
+
+    /**
+     * Returns the formatted string for the quantity chosen for the given selection
+     *
+     * @param Mage_Catalog_Model_Proudct $_selection
+     * @param bool                       $includeContainer
+     * @return string
+     */
+    public function getSelectionQtyTitlePrice($_selection, $includeContainer = true)
+    {
+        $price = $this->getProduct()->getPriceModel()->getSelectionPreFinalPrice($this->getProduct(), $_selection);
+        $this->setFormatProduct($_selection);
+        $priceTitle = $_selection->getSelectionQty() * 1 . ' x ' . $this->escapeHtml($_selection->getName());
+
+        if ($this->_canShowPrice()) {
+            $priceTitle .= ' &nbsp; ' . ($includeContainer ? '<span class="price-notice">' : '')
+                . '+' . $this->formatPriceString($price, $includeContainer)
+                . ($includeContainer ? '</span>' : '');
+        }
+
+        return $priceTitle;
+    }
+
+    /**
+     * Get title price for selection product
+     *
+     * @param Mage_Catalog_Model_Product $_selection
+     * @param bool $includeContainer
+     * @return string
+     */
+    public function getSelectionTitlePrice($_selection, $includeContainer = true)
+    {
+        $price = $this->getProduct()->getPriceModel()->getSelectionPreFinalPrice($this->getProduct(), $_selection, 1);
+        $this->setFormatProduct($_selection);
+        $priceTitle = $this->escapeHtml($_selection->getName());
+
+        if ($this->_canShowPrice()) {
+            $priceTitle .= ' &nbsp; ' . ($includeContainer ? '<span class="price-notice">' : '')
+                . '+' . $this->formatPriceString($price, $includeContainer)
+                . ($includeContainer ? '</span>' : '');
+        }
+
+        return $priceTitle;
+    }
+}

--- a/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
+++ b/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+
+/**
+ * Bundle option checkbox type renderer
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+class Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Checkbox
+    extends Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option
+{
+    /**
+     * Set template
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->setTemplate('bundle/catalog/product/view/type/bundle/option/checkbox.phtml');
+    }
+}

--- a/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+
+/**
+ * Bundle option multi select type renderer
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+class Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Multi
+    extends Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option
+{
+    /**
+     * Set template
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->setTemplate('bundle/catalog/product/view/type/bundle/option/multi.phtml');
+    }
+}

--- a/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Radio.php
+++ b/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Radio.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+
+/**
+ * Bundle option radiobox type renderer
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+class Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Radio
+    extends Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option
+{
+    /**
+     * Set template
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->setTemplate('bundle/catalog/product/view/type/bundle/option/radio.phtml');
+    }
+}

--- a/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Select.php
+++ b/app/code/community/Sitewards/B2BProfessional/Block/Bundle/Catalog/Product/View/Type/Bundle/Option/Select.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @copyright  Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+
+/**
+ * Bundle option dropdown type renderer
+ *
+ * @category    Mage
+ * @package     Mage_Bundle
+ * @author      Magento Core Team <core@magentocommerce.com>
+ */
+class Mage_Bundle_Block_Catalog_Product_View_Type_Bundle_Option_Select
+    extends Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option
+{
+    /**
+     * Set template
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->setTemplate('bundle/catalog/product/view/type/bundle/option/select.phtml');
+    }
+}

--- a/app/code/community/Sitewards/B2BProfessional/etc/config.xml
+++ b/app/code/community/Sitewards/B2BProfessional/etc/config.xml
@@ -22,6 +22,14 @@
                     <product_list>Sitewards_B2BProfessional_Block_Catalog_Product_List</product_list>
                 </rewrite>
             </catalog>
+            <bundle>
+                <rewrite>
+                    <catalog_product_view_type_bundle_option_checkbox>Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Checkbox</catalog_product_view_type_bundle_option_checkbox>
+                    <catalog_product_view_type_bundle_option_multi>Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Multi</catalog_product_view_type_bundle_option_multi>
+                    <catalog_product_view_type_bundle_option_radio>Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Radio</catalog_product_view_type_bundle_option_radio>
+                    <catalog_product_view_type_bundle_option_select>Sitewards_B2BProfessional_Block_Bundle_Catalog_Product_View_Type_Bundle_Option_Select</catalog_product_view_type_bundle_option_select>
+                </rewrite>
+            </bundle>
         </blocks>
     </global>
     <frontend>


### PR DESCRIPTION
The prices for bundle products still appear on the product detail page.  This overrides the necessary blocks and hides the pricing when the customer is not logged in.